### PR TITLE
refactor tests

### DIFF
--- a/spec/moip2_spec.rb
+++ b/spec/moip2_spec.rb
@@ -29,7 +29,7 @@ describe Moip2 do
     end
     
     it "invalid enviroment error" do
-      expect{ Moip2.env=("bla") }.to raise_error
+      expect{ Moip2.env=("abc") }.to raise_error(Moip2::InvalidEnviromentError)
     end
     
     


### PR DESCRIPTION
@paniko0 conversando com o @brenooliveira ele me mostrou uma abordagem mais acertiva para o caso do teste. Antes o teste passava independente da exception levantada, mas o mais correto seria forçar a exception que foi criada quando o resultado é inesperado.

Quando chegar, se for preciso me dá um grito que eu te explico melhor.
