### PR TITLE
Add unreferenced endpoints

### DIFF
--- a/lib/moip2/api.rb
+++ b/lib/moip2/api.rb
@@ -27,6 +27,17 @@ module Moip2
       Moip2::KeysApi.new(client)
     end
 
+    def customer
+      Moip2::CustomerApi.new(client)
+    end
+
+    def multi_order
+      Moip2::MultiOrderApi.new(client)
+    end
+
+    def multi_payment
+      Moip2::MultiPaymentApi.new(client)
+    end
   end
 
 end

--- a/spec/moip2/api_spec.rb
+++ b/spec/moip2/api_spec.rb
@@ -29,4 +29,15 @@ describe Moip2::Api do
     it { expect(api.keys).to be_a Moip2::KeysApi }
   end
 
+  describe "#customer" do
+    it { expect(api.customer).to be_a Moip2::CustomerApi }
+  end
+
+  describe "#multi_order" do
+    it { expect(api.multi_order).to be_a Moip2::MultiOrderApi }
+  end
+
+  describe "#multi_payment" do
+    it { expect(api.multi_payment).to be_a Moip2::MultiPaymentApi }
+  end
 end


### PR DESCRIPTION
This PR adds references to endpoints which had implementations + tests, but had not been made available through references in `api.rb`.