### PR TITLE
Chore: Add User-Agent to match Moip's new standard

### DIFF
--- a/lib/moip2/client.rb
+++ b/lib/moip2/client.rb
@@ -28,6 +28,7 @@ module Moip2
       opts[:headers].merge!(
         "Content-Type" => "application/json",
         "Authorization" => auth.header,
+        "User-Agent" => "MoipRubySDK/#{Moip2::VERSION} (+https://github.com/moip/moip-sdk-ruby)",
       )
 
       opts


### PR DESCRIPTION
This PR updates the default User Agent header to match the new standard for Moip's SDKs (`Moip#{lang}SDK/#{version} (#{github_uri})`).