### PR TITLE
Fix typo in example

### DIFF
--- a/examples/marketplace/payment-with-pre-authorization.rb
+++ b/examples/marketplace/payment-with-pre-authorization.rb
@@ -79,7 +79,7 @@ payment = api.payment.create(order.id,
   })
 
 # Capture pre authorized payment
-api.payment.catpure(payment.id)
+api.payment.capture(payment.id)
 
 # TIP: To get your application synchronized to Moip's platform,
 # you should have a route that handles Webhooks.


### PR DESCRIPTION
Proposing this to fix a typo in payment-with-pre-authorization.rb file.

Line 82 says api.payment.catpure(payment.id) when the correct method name is capture.

## PR Summary

## Detailed description
  #### Example:
  - Fixed a typo

## Checklist
  - [Not needed] Added tests
  - [X] All existing and new tests pass
  - [Not needed] Updated README (if appropriate)
  - [X] Code lints (Rubocop) successfully
  - [X] Commits are according to our commit guidelines
