### PR TITLE
Change API subdomain

### DIFF
--- a/lib/moip2/client.rb
+++ b/lib/moip2/client.rb
@@ -64,7 +64,7 @@ module Moip2
 
     def host
       if production?
-        "api.moip.com.br"
+        "api-waf.moip.com.br"
       else
         "sandbox.moip.com.br"
       end


### PR DESCRIPTION
## PR Summary

## Detailed description
  #### Change API URL:
This PR change the API URL by Moip resource requirements
  -  Change API URL from api.moip.com.br to api-waf.moip.com.br 

## Checklist
  - [ ] Added tests
  - [x] All existing and new tests pass
  - [ ] Updated README (if appropriate)
  - [x] Code lints (Rubocop) successfully
  - [x] Commits are according to our commit guidelines
